### PR TITLE
Fixed a bug in replaceRasterValues.py

### DIFF
--- a/pyRaster/replaceRasterValues.py
+++ b/pyRaster/replaceRasterValues.py
@@ -130,8 +130,8 @@ print(' Value at bottom right: {} '.format(R[p2[0]-1,p2[1]-1]))
 idR = replaceMask( R , p1, p2, lineMode, gtval, ltval, Nbd )
 
 if( useNans ): 
-  val = np.nan
   R = R.astype(float)
+  R[idR] = np.nan
 elif( filereplace is not None ):
   Rrdict = readNumpyZTile( filereplace )
   Rr = Rrdict['R']


### PR DESCRIPTION
Replacement with nans in replaceRasterValues.py was broken earlier, probably in commit 889d674e7e3e604da83f21fbdd0617631ddd38c5.

