### PR TITLE
In replaceRasterValues, the use of an int array causes type error.

### DIFF
--- a/pyRaster/replaceRasterValues.py
+++ b/pyRaster/replaceRasterValues.py
@@ -146,7 +146,7 @@ elif( val is not None):
   R[idR] = val
   
 if( not useNans ): 
-  R[idR] *= cf
+  R[idR] = R[idR]*cf
 
 Rdict['R'] = R
 


### PR DESCRIPTION
replaceRasterValues-skripti ei toimi jos operoitava rasteri ei ole täytetty liukuluvuiilla. Tällainen tilanne voi tulla vastaan esim. rakennus-ID:eiden kanssa toimittaessa.