### PR TITLE
Refine building IDs

### DIFF
--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -740,5 +740,36 @@ def interpolateOverNans( R ):
   return R
 
 # =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+
+def slowCoarsen(R,Rdims,s,n1,n2,e1,e2,Rtype):
+  '''Function to coarsen an integer field using the most common value. This is relatively slow for strong coarsenings.'''
+  from scipy import stats
+  print(' Coarsening with most common value.') 
+  maxDims = np.array(np.shape(R))
+  RT = np.zeros( np.append(Rdims,int(1/s)+1), Rtype )
+  i = np.zeros(Rdims,int)
+  for k in range(maxDims[0]):
+    for l in range(maxDims[1]):
+      RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R[ n1[k] ,e1[l] ]        
+      i[n2[k], e2[l]] += 1
+  RTT,RTTc = stats.mode(RT,axis=2)
+  return RTT[:,:,0]
+
+# =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+
+
+def fastCoarsen(R,Rdims,s,n1,n2,e1,e2,Rtype): 
+  '''Function to coarsen a field using the most common value. This is relatively fast for strong coarsenings.'''
+  print(' Coarsening with mean value.')
+  maxDims = np.array(np.shape(R))
+  R2 = np.zeros( Rdims, Rtype ) # Create the output array.
+  for k in range(maxDims[0]):
+    for l in range(maxDims[1]):
+      R2[ n2[k], e2[l] ] +=  R[ n1[k] ,e1[l] ]
+  R2 *= s
+  return R2
+
+
+# =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 # =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 # =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -75,14 +75,11 @@ n2 = n2.astype(int);  e2 = e2.astype(int)
 #np.savetxt('n2.dat', n2, fmt='%g')
 #np.savetxt('n1.dat', n1, fmt='%g')
 
-
-
-# Create the output array.
-R2 = np.zeros( R2dims, float )
-
 if( N > 0 ):
+  R2 = np.zeros( R2dims, float ) # Create the output array.
   R2[n2, e2] += R1[n1,e1]
 else:
+  R2 = np.zeros( R2dims, float ) # Create the output array.
   n2 = np.minimum( n2 , R2dims[0]-1)
   e2 = np.minimum( e2 , R2dims[1]-1)
   for k in range(maxDims[0]):
@@ -90,6 +87,7 @@ else:
       R2[ n2[k], e2[l] ] +=  R1[ n1[k] ,e1[l] ]
       #if( n2[k] == 0  and e2[l] == 0): 
       #  print(' R2 = {} , R1 = {} '.format( R2[ n2[k], e2[l] ], R1[ n1[k] ,e1[l] ]))
+  R2 *= s2
 
 
 #print(' TL:{} TR:{} BL:{} BR:{} '.format( R2[0,0], R2[0,-1], R2[-1,0], R2[-1,-1]))
@@ -98,7 +96,6 @@ else:
 # NOTE! The global origin is the coordinate of the top left cell center. 
 # Therefore, it must be shifted by in accordance to the top left cc's new location.
 R1 = None
-R2 *= s2
 Rdict['R'] = R2
 
 # Select the smaller delta

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -17,7 +17,8 @@ Author: Mikko Auvinen
 
 #==========================================================#
 parser = argparse.ArgumentParser(prog='refineTileResolution.py',description="Refine or coarsen a raster. When coarsening, the "
-                          "new value will be the mean of the corresponding cells in the fine raster unless specified otherwise.")
+"new value will be the mean of the corresponding cells in the fine raster unless specified otherwise. NB! Does not work "
+                                 "properly if raster contains missing values or NaNs.")
 parser.add_argument("-f", "--filename",type=str, help="Name of the .npz data file.")
 parser.add_argument("-fo", "--fileout",type=str, help="Name of output Palm/npz topography file.",\
   default="TOPOGRAPHY_MOD")
@@ -91,13 +92,15 @@ if( N > 0 ):
   R2 = np.zeros( R2dims, Rtype ) # Create the output array.
   R2[n2, e2] += R1[n1,e1]
 elif  np.isclose(np.around(1/s2),1/s2,0.001):
-  RT = np.full( np.append(R2dims,int(1/s2)),-9999, Rtype )
+  RT = np.zeros( np.append(R2dims,int(1/s2))+1, Rtype )
+  i = np.zeros(R2dims,int)
   n2 = np.minimum( n2 , R2dims[0]-1)
   e2 = np.minimum( e2 , R2dims[1]-1)
   for k in range(maxDims[0]):
     for l in range(maxDims[1]):
-      i = np.argmax( np.isclose(RT[ n2[k], e2[l], 1: ],-9999, 0.01 )  ) + 1
-      RT[ n2[k], e2[l], i] =  R1[ n1[k] ,e1[l] ]        
+#      i = np.argmax( np.isclose(RT[ n2[k], e2[l], 1: ],-9999, 0.01 )  ) + 1    
+      RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R1[ n1[k] ,e1[l] ]        
+      i[n2[k], e2[l]] += 1
   if mode:
     print(' Coarsening with most common value.') 
     RTT,RTTc = stats.mode(RT,axis=2)

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -16,8 +16,8 @@ Author: Mikko Auvinen
 '''
 
 #==========================================================#
-parser = argparse.ArgumentParser(prog='refineTileResolution.py',description="Refine or coarsen a raster. When coarsening, the 
-new value will be the mean of the corresponding cells in the fine raster unless specified otherwise.")
+parser = argparse.ArgumentParser(prog='refineTileResolution.py',description="Refine or coarsen a raster. When coarsening, the "
+                          "new value will be the mean of the corresponding cells in the fine raster unless specified otherwise.")
 parser.add_argument("-f", "--filename",type=str, help="Name of the .npz data file.")
 parser.add_argument("-fo", "--fileout",type=str, help="Name of output Palm/npz topography file.",\
   default="TOPOGRAPHY_MOD")

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -6,6 +6,7 @@ from utilities import writeLog
 from plotTools import addImagePlot
 import matplotlib.pyplot as plt
 from scipy import stats
+import sys
 '''
 Description:
 
@@ -92,16 +93,16 @@ if( N > 0 ):
   R2 = np.zeros( R2dims, Rtype ) # Create the output array.
   R2[n2, e2] += R1[n1,e1]
 elif  np.isclose(np.around(1/s2),1/s2,0.001):
-  RT = np.zeros( np.append(R2dims,int(1/s2)+1), Rtype )
-  i = np.zeros(R2dims,int)
-  n2 = np.minimum( n2 , R2dims[0]-1)
-  e2 = np.minimum( e2 , R2dims[1]-1)
-  for k in range(maxDims[0]):
-    for l in range(maxDims[1]):
-      RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R1[ n1[k] ,e1[l] ]        
-      i[n2[k], e2[l]] += 1
   if mode:
     print(' Coarsening with most common value.') 
+    RT = np.zeros( np.append(R2dims,int(1/s2)+1), Rtype )
+    i = np.zeros(R2dims,int)
+    n2 = np.minimum( n2 , R2dims[0]-1)
+    e2 = np.minimum( e2 , R2dims[1]-1)
+    for k in range(maxDims[0]):
+      for l in range(maxDims[1]):
+        RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R1[ n1[k] ,e1[l] ]        
+        i[n2[k], e2[l]] += 1
     RTT,RTTc = stats.mode(RT,axis=2)
     RT=None
     RTTc = None
@@ -109,20 +110,18 @@ elif  np.isclose(np.around(1/s2),1/s2,0.001):
     RTT=None
   else:
     print(' Coarsening with mean value.')
-    R2 = np.mean(RT,axis=2)
-    RT=None
+    # Calculate mean using finer grid
+    R2 = np.zeros( R2dims, Rtype ) # Create the output array.
+    n2 = np.minimum( n2 , R2dims[0]-1)
+    e2 = np.minimum( e2 , R2dims[1]-1)
+    for k in range(maxDims[0]):
+      for l in range(maxDims[1]):
+        R2[ n2[k], e2[l] ] +=  R1[ n1[k] ,e1[l] ]
+        #if( n2[k] == 0  and e2[l] == 0): 
+        #  print(' R2 = {} , R1 = {} '.format( R2[ n2[k], e2[l] ], R1[ n1[k] ,e1[l] ]))
+    R2 *= s2
 else:
-  # Calculate mean using finer grid
-  R2 = np.zeros( R2dims, Rtype ) # Create the output array.
-  n2 = np.minimum( n2 , R2dims[0]-1)
-  e2 = np.minimum( e2 , R2dims[1]-1)
-  for k in range(maxDims[0]):
-    for l in range(maxDims[1]):
-      R2[ n2[k], e2[l] ] +=  R1[ n1[k] ,e1[l] ]
-      #if( n2[k] == 0  and e2[l] == 0): 
-      #  print(' R2 = {} , R1 = {} '.format( R2[ n2[k], e2[l] ], R1[ n1[k] ,e1[l] ]))
-  R2 *= s2
-
+  sys.exit("ERROR: Attempting to coarsen with an incompatible refinement factor. Exiting.")
 
 
 #print(' TL:{} TR:{} BL:{} BR:{} '.format( R2[0,0], R2[0,-1], R2[-1,0], R2[-1,-1]))

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -92,13 +92,12 @@ if( N > 0 ):
   R2 = np.zeros( R2dims, Rtype ) # Create the output array.
   R2[n2, e2] += R1[n1,e1]
 elif  np.isclose(np.around(1/s2),1/s2,0.001):
-  RT = np.zeros( np.append(R2dims,int(1/s2))+1, Rtype )
+  RT = np.zeros( np.append(R2dims,int(1/s2)+1), Rtype )
   i = np.zeros(R2dims,int)
   n2 = np.minimum( n2 , R2dims[0]-1)
   e2 = np.minimum( e2 , R2dims[1]-1)
   for k in range(maxDims[0]):
     for l in range(maxDims[1]):
-#      i = np.argmax( np.isclose(RT[ n2[k], e2[l], 1: ],-9999, 0.01 )  ) + 1    
       RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R1[ n1[k] ,e1[l] ]        
       i[n2[k], e2[l]] += 1
   if mode:
@@ -111,6 +110,7 @@ elif  np.isclose(np.around(1/s2),1/s2,0.001):
   else:
     print(' Coarsening with mean value.')
     R2 = np.mean(RT,axis=2)
+    RT=None
 else:
   # Calculate mean using finer grid
   R2 = np.zeros( R2dims, Rtype ) # Create the output array.


### PR DESCRIPTION
Muutoksia refineTileResolution.py-skriptiin:
- Yleisempi muotoilu harvennukseen siten, että keskiarvon sijaan myös muut tavat siirtyä tiheältä harvalle hilalle onnistuvat pienillä muutoksille.
- Käyttäen yllä olevaa, harvennus jossa tiheän hilan yleisin arvo päätyy harvan hilan arvoksi. Ajateltu käytettäväksi rakennus-ID:teittn kanssa.
- Mahdollisuus tuoda ulos kokonaislukurastereita.