### PR TITLE
Bugfix to coarsening with refineTileResolution.py

### DIFF
--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -746,7 +746,7 @@ def slowCoarsen(R,Rdims,s,n1,n2,e1,e2,Rtype):
   from scipy import stats
   print(' Coarsening with most common value.') 
   maxDims = np.array(np.shape(R))
-  RT = np.zeros( np.append(Rdims,int(1/s)), Rtype )
+  RT = np.zeros( np.append(Rdims,int(np.round(1/s))), Rtype )
   i = np.zeros(Rdims,int)
   for k in range(maxDims[0]):
     for l in range(maxDims[1]):

--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -746,7 +746,7 @@ def slowCoarsen(R,Rdims,s,n1,n2,e1,e2,Rtype):
   from scipy import stats
   print(' Coarsening with most common value.') 
   maxDims = np.array(np.shape(R))
-  RT = np.zeros( np.append(Rdims,int(1/s)+1), Rtype )
+  RT = np.zeros( np.append(Rdims,int(1/s)), Rtype )
   i = np.zeros(Rdims,int)
   for k in range(maxDims[0]):
     for l in range(maxDims[1]):

--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -750,7 +750,10 @@ def slowCoarsen(R,Rdims,s,n1,n2,e1,e2,Rtype):
   i = np.zeros(Rdims,int)
   for k in range(maxDims[0]):
     for l in range(maxDims[1]):
-      RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R[ n1[k] ,e1[l] ]        
+      try:
+        RT[ n2[k], e2[l], i[n2[k], e2[l]]] =  R[ n1[k] ,e1[l] ]        
+      except IndexError:
+        sys.exit("ERROR: Incorrect index in RT or R array. Exiting. (slowCoarsen)")
       i[n2[k], e2[l]] += 1
   RTT,RTTc = stats.mode(RT,axis=2)
   return RTT[:,:,0]

--- a/pyRaster/refineTileResolution.py
+++ b/pyRaster/refineTileResolution.py
@@ -78,7 +78,7 @@ else:
 n1= n1/dr1; e1=e1/dr1
 n1 = n1.astype(int);  e1 = e1.astype(int)
 
-n2 = np.round(n2*fr2, decimals=2);  e2 = np.round(e2*fr2, decimals=2)
+n2 = np.floor((n2+0.5)*fr2);  e2 = np.floor((e2+0.5)*fr2)
 #print(' n2 = {} '.format(n2))
 #print(' n1 = {} '.format(n1))
 


### PR DESCRIPTION
Tarkemman rasterin pikselit jaettiin väärin harvemmalle rasterille kun refineTileResolution.py-skriptiä käytetään harvennukseen. 