### PR TITLE
Increase the raster size limit in PIL.

### DIFF
--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -605,6 +605,7 @@ def labelRaster(R, maskId=None):
 
 def openTifAsNumpy(tifFile):
   from PIL import Image
+  Image.MAX_IMAGE_PIXELS = 260000000
 
   im = Image.open(tifFile)
   #im.show()


### PR DESCRIPTION
PIL-kirjaston oletusasetuksilla vähän isompien tiffien aukaiseminen ei onnistu. Tämä muutos kasvattaa aukaistavan rasterin maksimikokoa.