### PR TITLE
Consistent default values for latitude in genPIDSInput.py

### DIFF
--- a/pyLib/pidsTools.py
+++ b/pyLib/pidsTools.py
@@ -49,8 +49,15 @@ def setPIDSGlobalAtrributes(ds, globalAttributes):
     try:
       setattr(ds, key, float(globalAttributes[key]))
     except KeyError:
-      if(getattr(ds, key, 0.0)==0.0):
-        setattr(ds, key, 0.0)
+      if key=='origin_lat':
+        if(getattr(ds, key, 0.0)==0.0):
+          print("WARNING: origin_lat (latitude) not set. Using default value (55˚).")
+          setattr(ds, key, 55.0)
+      else:
+        if key in ['origin_lon', 'rotation_angle']:
+          print("WARNING: "+key+" not set. Using default value (0.0).")
+        if(getattr(ds, key, 0.0)==0.0):
+          setattr(ds, key, 0.0)
 
   for key in intAttributeKeys:
     try:


### PR DESCRIPTION
Jos jonkin arvon jättää tyhjäksi genPIDSInputille, se laitetaan nollaksi tai tyhjäksi. Leveyspiirin tapauksessa tämä on ristiriidassa PARIN-tiedostossa käytetyn oletusarvon (55˚) kanssa. Vaihdoin tuon oletusarvon ja laitoin mukaan pari varoitusta kun PARIN-tiedoston sivuuttiavia oletusarvoja kirjotietaan PIDS_STATIC-tiedostoon.