### PR TITLE
A new switch for distributeValuesToAreas.py to limit building id size

### DIFF
--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -599,6 +599,22 @@ def labelRaster(R, maskId=None):
 
   return Rl, shapeCount
 
+# =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+
+def splitLabels(R, shapeCount, labelsize):
+  for i in range(1,shapeCount+1):
+    nlabels = np.count_nonzero(R==i)
+    if (nlabels > labelsize):
+      print(' Label '+str(i)+' exceeds maximum label size '+str(labelsize)+'. Splitting.')
+      labels = np.nonzero(R==i)
+      ej = 0
+      for j in range(1,nlabels//labelsize + 1):
+        R[(labels[0][ej*labelsize:j*labelsize],labels[1][ej*labelsize:j*labelsize])]=shapeCount+1
+        shapeCount=shapeCount+1
+        ej = j
+
+  return R, shapeCount
+
 
 # =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 

--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -606,18 +606,26 @@ def splitLabels(R, shapeCount, labelsize):
   for i in range(1,shapeCount+1):
     nlabels = np.count_nonzero(R==i)
     if (nlabels > labelsize):
-      print(' Label no.'+str(i)+' will be split. Original size: '+str(nlabels)+'.')      
-      L  = R==i
-      LU = np.zeros(L.shape,dtype=bool)
-      Lnz = np.nonzero(L)
-      LU[(Lnz[0][0],Lnz[1][0])] = True
-      while ( np.count_nonzero(LU) < labelsize): 
-        ULU = sn.binary_dilation(LU)*L
-        if (ULU==LU).all():
-          break
-        LU=ULU
-      shapeCount=shapeCount+1
-      R[LU]=shapeCount
+      print(' Label no. '+str(i)+' will be split. Original size: '+str(nlabels)+' px.')      
+      nleft = nlabels
+      while (nleft > labelsize):
+        L  = R==i
+        LU = np.zeros(L.shape,dtype=bool)
+        Lnz = np.nonzero(L)
+        LU[(Lnz[0][0],Lnz[1][0])] = True
+        nnonzero = np.count_nonzero(LU)        
+        while ( nnonzero < labelsize): 
+          VLU = LU
+          vnnonzero = nnonzero
+          LU = sn.binary_dilation(VLU)*L
+          if (VLU==LU).all():
+            break
+          nnonzero = np.count_nonzero(LU)
+        shapeCount=shapeCount+1
+        R[VLU]=shapeCount
+        print('   Created new label no. '+str(shapeCount)+' at size '+str(vnnonzero)+' px.')
+        nleft = nleft - vnnonzero
+      print('   Label no. '+str(i)+' is now at size '+str(nleft)+' px.')
 
   return R, shapeCount
 

--- a/pyLib/mapTools.py
+++ b/pyLib/mapTools.py
@@ -602,16 +602,22 @@ def labelRaster(R, maskId=None):
 # =*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 
 def splitLabels(R, shapeCount, labelsize):
+  import scipy.ndimage as sn
   for i in range(1,shapeCount+1):
     nlabels = np.count_nonzero(R==i)
     if (nlabels > labelsize):
-      print(' Label '+str(i)+' exceeds maximum label size '+str(labelsize)+'. Splitting.')
-      labels = np.nonzero(R==i)
-      ej = 0
-      for j in range(1,nlabels//labelsize + 1):
-        R[(labels[0][ej*labelsize:j*labelsize],labels[1][ej*labelsize:j*labelsize])]=shapeCount+1
-        shapeCount=shapeCount+1
-        ej = j
+      print(' Label no.'+str(i)+' will be split. Original size: '+str(nlabels)+'.')      
+      L  = R==i
+      LU = np.zeros(L.shape,dtype=bool)
+      Lnz = np.nonzero(L)
+      LU[(Lnz[0][0],Lnz[1][0])] = True
+      while ( np.count_nonzero(LU) < labelsize): 
+        ULU = sn.binary_dilation(LU)*L
+        if (ULU==LU).all():
+          break
+        LU=ULU
+      shapeCount=shapeCount+1
+      R[LU]=shapeCount
 
   return R, shapeCount
 

--- a/pyRaster/distributeValuesToAreas.py
+++ b/pyRaster/distributeValuesToAreas.py
@@ -123,7 +123,14 @@ if ( (None not in distribution) or labels):
       nlabels = np.count_nonzero(LR==i)
       if (nlabels > labelsize):
         print(' Label '+str(i)+' exceeds maximum label size '+str(labelsize)+'. Splitting.')
-              
+        labels = np.nonzero(LR==i)
+        ej = 0
+        for j in range(1,nlabels//labelsize + 1):
+          LR[(labels[0][ej*labelsize:j*labelsize],labels[1][ej*labelsize:j*labelsize])]=Nshapes+1
+          Nshapes=Nshapes+1
+          ej = j
+          
+        
 else:  # no need for labeling
   LR = R
   Nshapes = 1

--- a/pyRaster/distributeValuesToAreas.py
+++ b/pyRaster/distributeValuesToAreas.py
@@ -53,6 +53,8 @@ parser.add_argument("-vz", "--valueForZeros", type=float, default=None, \
   help=" Value to replace remaining zeros. Mean value --mean used as default.")
 parser.add_argument("-l", "--labels", action="store_true", default=False,\
   help="Output area labels. Useful in the creation of building IDs.")
+parser.add_argument("-s", "--labelsize", type=int, default=-1,\
+  help="Maximum size in pixels of area labels. Used only with --labels.")
 parser.add_argument("-p", "--printOn", action="store_true", default=False,\
   help="Print the resulting raster data.")
 parser.add_argument("-pp", "--printOnly",action="store_true", default=False,\
@@ -67,6 +69,7 @@ filetopo     = args.filetopo
 fileaug      = args.fileaugment
 distribution = args.distribution
 labels       = args.labels
+labelsize    = args.labelsize
 maskIds      = args.maskIds
 vmean        = args.mean
 vtkOn        = args.vtk 
@@ -115,6 +118,12 @@ Rdict['R'] = None
 # Label shapes from 0 to Nshapes-1 with SciPy ndimage package
 if ( (None not in distribution) or labels):
   LR, Nshapes = labelRaster(R, maskIds)
+  if (labelsize > 0):
+    for i in range(1,Nshapes+1):
+      nlabels = np.count_nonzero(LR==i)
+      if (nlabels > labelsize):
+        print(' Label '+str(i)+' exceeds maximum label size '+str(labelsize)+'. Splitting.')
+              
 else:  # no need for labeling
   LR = R
   Nshapes = 1

--- a/pyRaster/distributeValuesToAreas.py
+++ b/pyRaster/distributeValuesToAreas.py
@@ -54,7 +54,7 @@ parser.add_argument("-vz", "--valueForZeros", type=float, default=None, \
 parser.add_argument("-l", "--labels", action="store_true", default=False,\
   help="Output area labels. Useful in the creation of building IDs.")
 parser.add_argument("-s", "--labelsize", type=int, default=-1,\
-  help="Maximum size in pixels of area labels. Used only with --labels.")
+  help="Maximum size in pixels of area labels. Used only with --labels. NB! This option can slow down the script significantly.")
 parser.add_argument("-p", "--printOn", action="store_true", default=False,\
   help="Print the resulting raster data.")
 parser.add_argument("-pp", "--printOnly",action="store_true", default=False,\

--- a/pyRaster/distributeValuesToAreas.py
+++ b/pyRaster/distributeValuesToAreas.py
@@ -119,18 +119,7 @@ Rdict['R'] = None
 if ( (None not in distribution) or labels):
   LR, Nshapes = labelRaster(R, maskIds)
   if (labelsize > 0):
-    for i in range(1,Nshapes+1):
-      nlabels = np.count_nonzero(LR==i)
-      if (nlabels > labelsize):
-        print(' Label '+str(i)+' exceeds maximum label size '+str(labelsize)+'. Splitting.')
-        labels = np.nonzero(LR==i)
-        ej = 0
-        for j in range(1,nlabels//labelsize + 1):
-          LR[(labels[0][ej*labelsize:j*labelsize],labels[1][ej*labelsize:j*labelsize])]=Nshapes+1
-          Nshapes=Nshapes+1
-          ej = j
-          
-        
+    LR, Nshapes = splitLabels(LR, Nshapes, labelsize)                 
 else:  # no need for labeling
   LR = R
   Nshapes = 1


### PR DESCRIPTION
Lisäsin  distributeValuesToAreas.py-skriptiin uuden toiminnallisuuden jonka avulla rakennus-ID:tä luodessa voi rajoittaa ulos tulevan rakennuksen kokoa. Vaikuttaa toimivan mutta on hieman hidas.